### PR TITLE
♻️ eliminate checks on user approval

### DIFF
--- a/example/dapp/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/dapp/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
-import shared_preferences_macos
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/example/wallet/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/wallet/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
-import shared_preferences_macos
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/lib/core/subscriber/models.g.dart
+++ b/lib/core/subscriber/models.g.dart
@@ -16,7 +16,7 @@ SubscriberActive _$SubscriberActiveFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$SubscriberActiveToJson(SubscriberActive instance) =>
     <String, dynamic>{
-      'id': instance.id,
       'relay': instance.relay.toJson(),
       'topic': instance.topic,
+      'id': instance.id,
     };

--- a/lib/sign/engine/engine.dart
+++ b/lib/sign/engine/engine.dart
@@ -1194,14 +1194,6 @@ class Engine with Events implements IEngine {
     if (validNamespacesError != null) {
       throw WCException(validNamespacesError.message);
     }
-    final conformingNamespacesError = isConformingNamespaces(
-      proposal.requiredNamespaces,
-      namespaces,
-      "update()",
-    );
-    if (conformingNamespacesError != null) {
-      throw WCException(conformingNamespacesError.message);
-    }
   }
 
   Future<void> _isValidReject(SessionRejectParams params) async {

--- a/lib/wc_utils/jsonrpc/models/models.dart
+++ b/lib/wc_utils/jsonrpc/models/models.dart
@@ -38,7 +38,7 @@ class RequestArguments<T> {
 }
 
 abstract class JsonRpcPayload<T> {
-  int get id;
+  dynamic get id;
   String get jsonrpc;
 
   Map<String, dynamic> toJson();
@@ -47,7 +47,7 @@ abstract class JsonRpcPayload<T> {
 class JsonRpcRequest<T> extends RequestArguments<T>
     implements JsonRpcPayload<T> {
   @override
-  final int id;
+  final dynamic id;
   @override
   final String jsonrpc;
 
@@ -84,7 +84,7 @@ abstract class JsonRpcResponse<T> implements JsonRpcPayload<T> {}
 
 class JsonRpcResult<T extends Object?> implements JsonRpcResponse<T> {
   @override
-  final int id;
+  final dynamic id;
   @override
   final String jsonrpc;
   final T? result;
@@ -121,7 +121,7 @@ class JsonRpcResult<T extends Object?> implements JsonRpcResponse<T> {
 
 class JsonRpcError implements JsonRpcResponse<ErrorResponse> {
   @override
-  final int id;
+  final dynamic id;
   @override
   final String jsonrpc;
   final ErrorResponse? error;


### PR DESCRIPTION
Hi there, I think the check for the "approve" data is not necessary, it is the user's freedom to decide which accounts of which chains they want to connect or approve which methods to provide which events.

Instead, if the Dapp confirms that "approve" is needed under certain chains, the Dapp side needs to go detect and alert the user, not force the user to "approve" the chains.